### PR TITLE
fix(build) - Whitelist get-contrast

### DIFF
--- a/ng-package.json
+++ b/ng-package.json
@@ -3,5 +3,8 @@
   "dest": "./dist",
   "lib": {
     "entryFile": "src/index.ts"
-  }
+  },
+  "whitelistedNonPeerDependencies": [
+		"get-contrast"
+	]
 }


### PR DESCRIPTION
Whitelist get-contrast to fix deployment of build - used for accessibility