### PR TITLE
feat(PageHeader): Updating trailing slash on page header and minor style

### DIFF
--- a/src/page-header/base/page-header.component.ts
+++ b/src/page-header/base/page-header.component.ts
@@ -64,6 +64,7 @@ export const itemsWithTitle = (items: BreadcrumbItem[], title: string): Breadcru
 					class="breadcrumbs"
 					[ariaLabel]="ariaLabel"
 					[items]="items"
+					[noTrailingSlash]="noTrailingSlash"
 					(navigation)="navigation.emit($event)">
 				</ibm-breadcrumb>
 				<div class="ibm--page-header__title-container">
@@ -124,6 +125,11 @@ export class PageHeaderComponent {
 	 * Custom bg color
 	 */
 	@Input() bgColor: string;
+
+	/**
+	 * Trailing Slash
+	 */
+	@Input() noTrailingSlash = false;
 
 	/**
 	 * Emits the navigation status promise when the link is activated

--- a/src/page-header/base/page-header.scss
+++ b/src/page-header/base/page-header.scss
@@ -61,6 +61,7 @@ $prefix: 'ibm';
   display: flex;
   justify-content: center;
   max-width: 100%;
+  align-items: baseline;
 
   > * {
     margin-left: 1rem;


### PR DESCRIPTION
Adding support for trailing slash control to page header.

Flex was stretching child items, align-items: baseline prevents this