### PR TITLE
fix(PageHeader): fix breadcrumb html appearing even if no breadcrumbs…

### DIFF
--- a/src/page-header/base/page-header.component.ts
+++ b/src/page-header/base/page-header.component.ts
@@ -60,7 +60,7 @@ export const itemsWithTitle = (items: BreadcrumbItem[], title: string): Breadcru
 		<div class="ibm--page-header__container"
 			[class.ibm--page-header__container--contained-width]="containedWidth">
 			<div class="ibm--page-header__main">
-				<ibm-breadcrumb
+				<ibm-breadcrumb *ngIf="items.length > 0"
 					class="breadcrumbs"
 					[ariaLabel]="ariaLabel"
 					[items]="items"

--- a/src/page-header/base/page-header.component.ts
+++ b/src/page-header/base/page-header.component.ts
@@ -61,7 +61,7 @@ export const itemsWithTitle = (items: BreadcrumbItem[], title: string): Breadcru
 			[class.ibm--page-header__container--contained-width]="containedWidth">
 			<div class="ibm--page-header__main">
 				<ibm-breadcrumb 
-					*ngIf="items.length > 0"
+					*ngIf="items.length"
 					class="breadcrumbs"
 					[ariaLabel]="ariaLabel"
 					[items]="items"

--- a/src/page-header/base/page-header.component.ts
+++ b/src/page-header/base/page-header.component.ts
@@ -60,7 +60,7 @@ export const itemsWithTitle = (items: BreadcrumbItem[], title: string): Breadcru
 		<div class="ibm--page-header__container"
 			[class.ibm--page-header__container--contained-width]="containedWidth">
 			<div class="ibm--page-header__main">
-				<ibm-breadcrumb 
+				<ibm-breadcrumb
 					*ngIf="items.length"
 					class="breadcrumbs"
 					[ariaLabel]="ariaLabel"

--- a/src/page-header/base/page-header.component.ts
+++ b/src/page-header/base/page-header.component.ts
@@ -60,7 +60,8 @@ export const itemsWithTitle = (items: BreadcrumbItem[], title: string): Breadcru
 		<div class="ibm--page-header__container"
 			[class.ibm--page-header__container--contained-width]="containedWidth">
 			<div class="ibm--page-header__main">
-				<ibm-breadcrumb *ngIf="items.length > 0"
+				<ibm-breadcrumb 
+					*ngIf="items.length > 0"
 					class="breadcrumbs"
 					[ariaLabel]="ariaLabel"
 					[items]="items"


### PR DESCRIPTION
Adding conditional check to breadcrumb component to prevent breadcrumb html being added to dom when no breadcrumbs exist. 

This fixes accessibility issue where when no breadcrumbs existed the nav element would still be added with no children 
